### PR TITLE
Added .sublime-settings-file support and a option to ignore empty lines rather than to break on them

### DIFF
--- a/valign.py
+++ b/valign.py
@@ -11,10 +11,11 @@ class ValignCommand(sublime_plugin.TextCommand):
 		return view.substr(line)
 	
 	# Expands the set of rows to all of the lines that match the current indentation level and are
-	# not empty.
+	# not empty; except the stop_empty option is false
 	def expand_rows_to_indentation(self):
 		view          = self.view
 		current_row   = self.start_row
+		next_row      = current_row
 		rows          = self.rows
 		line_count, _ = self.view.rowcol(self.view.size())
 		indentation   = -1
@@ -22,10 +23,19 @@ class ValignCommand(sublime_plugin.TextCommand):
 		# Expand upward and then downward from the selection.
 		for direction in [-1, 1]:
 			while current_row >= 0 and current_row < line_count + 1:
+				# Set current_row on the next row; this does nothing for the first iteration but
+				# increments current_row later on. This is necessary to ensure a correct
+				# functionality of the "continue" statement
+				current_row = next_row
+				# Increment next_row for the next iteration
+				next_row += direction
+
 				line_string = self.get_line_string_for_row(current_row)
 				
-				# Stop at empty lines.
-				if len(line_string.strip()) == 0: break
+				# Stop at empty lines or skip them.
+				if len(line_string.strip()) == 0:
+					if self.stop_empty: break
+					else: continue
 				
 				# Calculate the current indentation level.
 				match               = re.search("^\s+", line_string)
@@ -50,12 +60,10 @@ class ValignCommand(sublime_plugin.TextCommand):
 						rows.insert(0, current_row)
 					else:
 						rows.append(current_row)
-				
-				# Move on to the next row.
-				current_row += direction
 			
 			# Reset the current row for moving downward.
 			current_row = rows[len(rows) - 1] + 1
+			next_row    = current_row
 	
 	# Returns the character to align on based on the start row. Returns None if no proper character
 	# is found.
@@ -227,6 +235,7 @@ class ValignCommand(sublime_plugin.TextCommand):
 				}
 			])
 		)
+		self.stop_empty = valign_settings.get("stop_empty", settings.get("va_stop_empty", True))
 		
 		# Bail if our start row is empty.
 		if len(self.get_line_string_for_row(self.start_row).strip()) == 0: return


### PR DESCRIPTION
I ensured that the old configuration in the user config file is still valid and possible. But the plugin now "prefers" a own config file.

(Sorry for the double pull request but I noticed a bug in the last second.)
